### PR TITLE
Evangelists work internally too

### DIFF
--- a/evangelistmanifesto.asciidoc
+++ b/evangelistmanifesto.asciidoc
@@ -75,6 +75,11 @@ shows, working at hackathons, talking or teaching at meetups
 especially regarding roadmap issues so they can effectively communicate 
 the product intention and direction to external developers
 
+* They need to be key stakeholders in the specification and development of
+developer-targeted features; as the main point of contact with developer
+users outside the organisation, their feedback should enhance the feature
+in order to meet those external developer's requirements
+
 * They need to be able to spend time talking to product engineers so they
 can effectively understand how the technology is supposed to work and 
 give feedback so the engineers can understand how developers will use 


### PR DESCRIPTION
Evangelists should be able to positively influence the internal development of features too, by providing insight and improvements based on working closely with external developers who use the product / service.
